### PR TITLE
use packit's way of doing versions

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -9,8 +9,6 @@ synced_files:
     - .packit.yaml
     - criu-tmpfiles.conf
 
-current_version_command: ["make", "show-version"]
-
 # name in upstream package repository/registry (e.g. in PyPI)
 upstream_package_name: criu
 # downstream (Fedora) RPM package name
@@ -19,7 +17,8 @@ actions:
   post-upstream-clone:
   - "wget https://src.fedoraproject.org/rpms/criu/raw/rawhide/f/criu.spec -O criu.spec"
   - "wget https://src.fedoraproject.org/rpms/criu/raw/rawhide/f/criu-tmpfiles.conf -O criu-tmpfiles.conf"
-
+#   get-current-version:
+#   - bash -c "make show-version | sed s/\\-/./"
 jobs:
 - job: copr_build
   trigger: pull_request

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,28 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: criu.spec
+
+# add or remove files that should be synced
+synced_files:
+    - criu.spec
+    - .packit.yaml
+    - criu-tmpfiles.conf
+
+current_version_command: ["make", "show-version"]
+
+# name in upstream package repository/registry (e.g. in PyPI)
+upstream_package_name: criu
+# downstream (Fedora) RPM package name
+downstream_package_name: criu
+actions:
+  post-upstream-clone:
+  - "wget https://src.fedoraproject.org/rpms/criu/raw/rawhide/f/criu.spec -O criu.spec"
+  - "wget https://src.fedoraproject.org/rpms/criu/raw/rawhide/f/criu-tmpfiles.conf -O criu-tmpfiles.conf"
+
+jobs:
+- job: copr_build
+  trigger: pull_request
+  metadata:
+    targets:
+    - fedora-all

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ criu-deps	+= include/common/asm
 #
 # Configure variables.
 export CONFIG_HEADER := include/common/config.h
-ifeq ($(filter tags etags cscope clean mrproper,$(MAKECMDGOALS)),)
+ifeq ($(filter tags etags cscope clean mrproper show-version help,$(MAKECMDGOALS)),)
 include Makefile.config
 else
 # To clean all files, enable make/build options here
@@ -349,6 +349,10 @@ criu-$(tar-name).tar.bz2:
 dist tar: criu-$(tar-name).tar.bz2 ;
 .PHONY: dist tar
 
+show-version:
+	@echo $(head-name)
+.PHONY: show-version
+
 TAGS_FILES_REGEXP := . -name '*.[hcS]' ! -path './.*' \( ! -path './test/*' -o -path './test/zdtm/lib/*' \)
 tags:
 	$(call msg-gen, $@)
@@ -402,6 +406,7 @@ help:
 	@echo '      cscope          - Generate cscope database'
 	@echo '      test            - Run zdtm test-suite'
 	@echo '      gcov            - Make code coverage report'
+	@echo '      show-version    - Show current CRIU version'
 .PHONY: help
 
 lint:


### PR DESCRIPTION
    make show-version
    v1.5.5394-g96eabf6f

rpm hates the '-' in the version field, packit by default replaces those
with dots to make rpm happy
